### PR TITLE
Fix permissions issues on /bin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,7 +196,7 @@ default         0;
 sudo cp -r stratum /var/stratum
 sudo cp -r run.sh /var/stratum
 cd $HOME/yiimp
-sudo cp -a $HOME/yiimp/bin/. /bin/
+sudo cp -r $HOME/yiimp/bin/. /bin/
 sudo cp -r $HOME/yiimp/blocknotify/blocknotify /var/stratum
 sudo mkdir -p /etc/yiimp
 sudo mkdir -p /$HOME/backup/


### PR DESCRIPTION
Resolves changing owner ship on root bin folder when yiimp bins are copied over from users home directory. 